### PR TITLE
Add RFC for non-nullable list only required on output types

### DIFF
--- a/rfcs/20220620-non_nullable_lists_input_types-fields.md
+++ b/rfcs/20220620-non_nullable_lists_input_types-fields.md
@@ -4,7 +4,7 @@
 
 > One paragraph explanation of the change.
 
-All output types **MUST** have non-nullable lists fields
+All output types **MUST** have non-nullable lists fields.
 
 ## Motivation
 
@@ -12,13 +12,13 @@ All output types **MUST** have non-nullable lists fields
 outcome?
 
 Sometimes users would like to not supply a list when doing input objects.  
-However as the rules enforces all list to be non-nullable, this is not possible
+However as the rules enforces all list to be non-nullable, this is not possible.
 
 ## User impact
 
 > Is the impact on users major? How will they benefit from this proposal?
 
-None. There are no breaking changes, it's only loosening the current rules
+None. There are no breaking changes, it's only loosening the current rules.
 
 ## Design Proposal
 
@@ -26,7 +26,7 @@ None. There are no breaking changes, it's only loosening the current rules
 > where there and why this solution over them?
 
 When creating a list, it can be nullable if it is not an output type.  
-Output type is defined as per graphql spec http://spec.graphql.org/draft/#sec-Input-and-Output-Types.
+Output type is defined as per GraphQL spec https://spec.graphql.org/draft/#sec-Input-and-Output-Types.
 
 Essentially this means that all lists which are on an `input` object are allowed to be null, however not
 enforced to be null. The following is now valid.

--- a/rfcs/20220620-non_nullable_lists_input_types-fields.md
+++ b/rfcs/20220620-non_nullable_lists_input_types-fields.md
@@ -1,0 +1,47 @@
+# Enforce NonNullable list requirement on output types only
+
+## Summary
+
+> One paragraph explanation of the change.
+
+All output types **MUST** have non-nullable lists fields
+
+## Motivation
+
+> Why are we doing this? What use cases does it support? What is the expected
+outcome?
+
+Sometimes users would like to not supply a list when doing input objects.  
+However as the rules enforces all list to be non-nullable, this is not possible
+
+## User impact
+
+> Is the impact on users major? How will they benefit from this proposal?
+
+None. There are no breaking changes, it's only loosening the current rules
+
+## Design Proposal
+
+> The core of proposal. How does it work? What are the pros/cons? What alternatives
+> where there and why this solution over them?
+
+When creating a list, it can be nullable if it is not an output type.  
+Output type is defined as per graphql spec http://spec.graphql.org/draft/#sec-Input-and-Output-Types.
+
+Essentially this means that all lists which are on an `input` object are allowed to be null, however not
+enforced to be null. The following is now valid.
+
+> :white_check_mark: Valid
+```graphql
+input PersonInput {
+    friends: [String!]
+    parents: [String!]!
+}
+```
+
+## Implementation
+
+> How should this be implemented in the automated tool for validating the rules?
+
+Check the type definition of the field and check if that is of type `input`.
+If it is then skip it.

--- a/rules.md
+++ b/rules.md
@@ -107,9 +107,10 @@ type User {
 ```
 
 ## Lists are non-nullable ![linting](https://img.shields.io/badge/linting-auto-blue)
-All fields with a list value **MUST** be non-nullable.
+All fields with a list value **MUST** be non-nullable when field definition is output type.
 
-When declaring a list field, the value **MUST** always be a list (either empty, or populated).
+When declaring a list field, the value **MUST** always be a list (either empty, or populated) on [output types](http://spec.graphql.org/draft/#sec-Input-and-Output-Types).  
+It is allowed to have list fields on `input` types which are nullable.
 
 > ❌ Invalid
 ```graphql
@@ -129,6 +130,10 @@ type Company {
     The use of non-nullable enforcement means that the value will only ever be `[]` or a populated list.
     """
     invoices: [Invoice!]!
+}
+
+input CompanyInput {
+    owners: [String!]
 }
 ```
 


### PR DESCRIPTION
> :white_check_mark: Valid
```graphql
input PersonInput {
    friends: [String!]
    parents: [String!]!
}
```